### PR TITLE
Add required title property to author and tag types

### DIFF
--- a/types/author.yml
+++ b/types/author.yml
@@ -3,6 +3,9 @@ paths:
     - blog/authors
 
 properties:
+    title:
+        type: string
+        required: true
     image:
         type: asset
         required: true

--- a/types/tag.yml
+++ b/types/tag.yml
@@ -3,6 +3,9 @@ paths:
     - blog/tags
 
 properties:
+    title:
+        type: string
+        required: true
     order:
         type: int
         required: true


### PR DESCRIPTION
Introduces a required 'title' string property to both the author and tag YAML type definitions to ensure each entry includes a title.